### PR TITLE
Make the tenant connection configurable

### DIFF
--- a/src/Abstracts/Models/TenantModel.php
+++ b/src/Abstracts/Models/TenantModel.php
@@ -6,5 +6,11 @@ use HynMe\Framework\Models\AbstractModel;
 
 class TenantModel extends AbstractModel
 {
-    protected $connection = 'tenant';
+    protected $connection;
+
+    public function __construct(array $attributes = [])
+    {
+        $this->connection = env('TENANT_CONNECTION', 'tenant');
+        parent::__construct($attributes);
+    }
 }


### PR DESCRIPTION
I would like to make the tenant connection for TenantModels configurable so I can change the connection when running tests by changing the environment properties.

At the current moment I have to set-up an entire multi-tenant environment for each functionality that uses a tenant model. While that could be exactly what you need (testing multi-tenancy), at other times you only want to test a single slice of functionality.

__Use case:__
I want to test if my API-endpoint is formatting my model data properly.
This is not related to my multi-tenancy setup.

__Usage:__
By default the TENANT_CONNECTION resolves to tenant.
By setting TENANT_CONNECTION in your phpunit.xml file to `<env name="TENANT_CONNECTION" value="mysql"/>` the models are resolved from your default mysql database.
-Or-
By changing it on a per test basis:
```php
Class APIResponseTest extends TestCase {

    /**
     * Setup the test environment.
     *
     * @return void
     */
    public function setUp()
    {
        putenv('TENANT_CONNECTION=mysql');
        parent::setUp();
    }
```

Let me know if it makes sense to add this to the package, otherwise people can just create their own implementation of TenantModel and use these snippets to simplify some test set-ups.